### PR TITLE
Coerce odd types in provider

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import { createIntentMap, createMessageCollector } from "@botmock-api/utils";
+// import { toAdjMatrix } from "@botmock-api/flow-model";
 import { remove } from "fs-extra";
 import { Sema } from "async-sema";
 import mkdirp from "mkdirp";

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
 import "dotenv/config";
 import { createIntentMap, createMessageCollector } from "@botmock-api/utils";
-// import { toAdjMatrix } from "@botmock-api/flow-model";
 import { remove } from "fs-extra";
 import { Sema } from "async-sema";
 import mkdirp from "mkdirp";

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -26,8 +26,14 @@ export class Provider {
     let method = Object.getOwnPropertyNames(
       Object.getPrototypeOf(this.platform)
     ).find(prop => type.includes(prop));
-    if (type === "carousel") {
-      method = "list";
+    // coerce odd types
+    switch (type) {
+      case "delay":
+        method = "text";
+        break;
+      case "carousel":
+        method = "list";
+        break;
     }
     if (type.endsWith("button") || type.endsWith("generic")) {
       method = "card";

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -28,6 +28,7 @@ export class Provider {
     ).find(prop => type.includes(prop));
     // coerce odd types
     switch (type) {
+      case "api":
       case "delay":
         method = "text";
         break;


### PR DESCRIPTION
This PR add support for transforming odd block types (such as "delay" or "api") to types suitable for the Dialogflow import step.